### PR TITLE
클라이언트 응답에 처리율 제한 정보 추가

### DIFF
--- a/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
+++ b/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
@@ -17,7 +17,7 @@ import org.springframework.web.context.request.ServletRequestAttributes
 @Aspect
 @Component
 class RateLimiterAop(
-    @Qualifier("Bucket4jRateLimiter") private val rateLimiter: RateLimiter
+    @Qualifier("RedisRateLimiter") private val rateLimiter: RateLimiter
 ) {
 
     @Around("@annotation(com.example.common.annotation.LimitRequestPerTime)")

--- a/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
+++ b/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
@@ -17,7 +17,7 @@ import org.springframework.web.context.request.ServletRequestAttributes
 @Aspect
 @Component
 class RateLimiterAop(
-    @Qualifier("RedisRateLimiter") private val rateLimiter: RateLimiter
+    @Qualifier("RedisLuaRateLimiter") private val rateLimiter: RateLimiter
 ) {
 
     @Around("@annotation(com.example.common.annotation.LimitRequestPerTime)")

--- a/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
+++ b/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
@@ -17,7 +17,7 @@ import org.springframework.web.context.request.ServletRequestAttributes
 @Aspect
 @Component
 class RateLimiterAop(
-    @Qualifier("RedisLuaRateLimiter") private val rateLimiter: RateLimiter
+    @Qualifier("Bucket4jRateLimiter") private val rateLimiter: RateLimiter
 ) {
 
     @Around("@annotation(com.example.common.annotation.LimitRequestPerTime)")
@@ -49,6 +49,7 @@ class RateLimiterAop(
         response?.apply {
             setHeader("X-RateLimit-Limit", rateLimitResponse.limit.toString())
             setHeader("X-RateLimit-Remaining", rateLimitResponse.remaining.toString())
+            setHeader("X-RateLimit-RetryAfter", rateLimitResponse.retryAfter.toString())
         }
     }
 

--- a/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
+++ b/movie-common/src/main/kotlin/com/example/common/aspect/RateLimiterAop.kt
@@ -2,6 +2,7 @@ package com.example.common.aspect
 
 import com.example.common.annotation.LimitRequestPerTime
 import com.example.common.exception.RateLimitExceedException
+import com.example.common.model.RateLimitResponse
 import com.example.common.ratelimit.RateLimiter
 import com.example.common.util.CustomSpringELParser
 import org.aspectj.lang.ProceedingJoinPoint
@@ -10,11 +11,13 @@ import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
 
 @Aspect
 @Component
 class RateLimiterAop(
-    @Qualifier("RedisLuaRateLimiter") private val rateLimiter: RateLimiter
+    @Qualifier("Bucket4jRateLimiter") private val rateLimiter: RateLimiter
 ) {
 
     @Around("@annotation(com.example.common.annotation.LimitRequestPerTime)")
@@ -24,7 +27,11 @@ class RateLimiterAop(
 
         val key = "RATE-LIMIT:" + getKey(joinPoint, limitRequestPerTime)
 
-        if (!rateLimiter.tryCall(key, limitRequestPerTime)) {
+        val rateLimitResponse = rateLimiter.tryCall(key, limitRequestPerTime)
+
+        applyHttpHeader(rateLimitResponse)
+
+        if (!rateLimitResponse.allowed) {
             throw RateLimitExceedException(getMethodName(joinPoint))
         }
 
@@ -34,6 +41,15 @@ class RateLimiterAop(
     private fun getMethodName(joinPoint: ProceedingJoinPoint): String {
         val signature = joinPoint.signature as MethodSignature
         return signature.method.name
+    }
+
+    private fun applyHttpHeader(rateLimitResponse: RateLimitResponse) {
+        val response = (RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes)?.response
+
+        response?.apply {
+            setHeader("X-RateLimit-Limit", rateLimitResponse.limit.toString())
+            setHeader("X-RateLimit-Remaining", rateLimitResponse.remaining.toString())
+        }
     }
 
     private fun getKey(

--- a/movie-common/src/main/kotlin/com/example/common/config/RedisConfig.kt
+++ b/movie-common/src/main/kotlin/com/example/common/config/RedisConfig.kt
@@ -1,6 +1,5 @@
 package com.example.common.config
 
-import com.example.common.model.RateLimitResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator

--- a/movie-common/src/main/kotlin/com/example/common/config/RedisConfig.kt
+++ b/movie-common/src/main/kotlin/com/example/common/config/RedisConfig.kt
@@ -1,5 +1,6 @@
 package com.example.common.config
 
+import com.example.common.model.RateLimitResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
@@ -55,9 +56,9 @@ class RedisConfig(
     }
 
     @Bean
-    fun rateLimitScript(): RedisScript<Boolean> {
+    fun rateLimitScript(): RedisScript<List<*>> {
         val script = ClassPathResource("luascript/ratelimit.lua")
-        return RedisScript.of(script, Boolean::class.java)
+        return RedisScript.of(script, List::class.java)
     }
 
     @Bean

--- a/movie-common/src/main/kotlin/com/example/common/model/RateLimitResponse.kt
+++ b/movie-common/src/main/kotlin/com/example/common/model/RateLimitResponse.kt
@@ -1,0 +1,7 @@
+package com.example.common.model
+
+data class RateLimitResponse(
+    val allowed: Boolean,
+    val limit: Long,
+    val remaining: Long
+)

--- a/movie-common/src/main/kotlin/com/example/common/model/RateLimitResponse.kt
+++ b/movie-common/src/main/kotlin/com/example/common/model/RateLimitResponse.kt
@@ -1,7 +1,22 @@
 package com.example.common.model
 
+import java.time.LocalDateTime
+
 data class RateLimitResponse(
     val allowed: Boolean,
     val limit: Long,
-    val remaining: Long
-)
+    val remaining: Long,
+    val retryAfter: LocalDateTime? = null
+) {
+
+    companion object {
+        fun success(allowed: Boolean, limit: Long, remaining: Long): RateLimitResponse {
+            return RateLimitResponse(allowed, limit, remaining, null)
+        }
+
+        fun fail(allowed: Boolean, limit: Long, remaining: Long, retryAfter: LocalDateTime?): RateLimitResponse {
+            return RateLimitResponse(allowed, limit, remaining, retryAfter)
+        }
+    }
+
+}

--- a/movie-common/src/main/kotlin/com/example/common/ratelimit/Bucket4jRateLimiter.kt
+++ b/movie-common/src/main/kotlin/com/example/common/ratelimit/Bucket4jRateLimiter.kt
@@ -2,59 +2,57 @@ package com.example.common.ratelimit
 
 import com.example.common.annotation.LimitRequestPerTime
 import com.example.common.model.RateLimitResponse
+import com.example.common.util.TimeUtil
 import io.github.bucket4j.Bucket
 import org.springframework.stereotype.Component
-import java.time.Duration
 import java.time.LocalDateTime
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 
 @Component("Bucket4jRateLimiter")
 class Bucket4jRateLimiter: RateLimiter {
 
-    private val tokenStorage = ConcurrentHashMap<String, Bucket>()
+    private val bucketStorage = ConcurrentHashMap<String, Bucket>()
+    private val retryTimeStorage = ConcurrentHashMap<String, LocalDateTime>()
 
     override fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): RateLimitResponse {
         val bucket = resolveBucket(key, limitRequestPerTime)
 
-        val probe = bucket.tryConsumeAndReturnRemaining(1)
+        val isConsumed = bucket.tryConsume(1)
 
-        return if (probe.isConsumed) {
+        return if (isConsumed) {
             RateLimitResponse.success(
                 allowed = true,
                 limit = limitRequestPerTime.limitCount,
-                probe.remainingTokens
+                bucket.availableTokens
             )
         } else {
-            val nanosToWait = probe.nanosToWaitForRefill
-            val retryAfterTime = LocalDateTime.now().plusNanos(nanosToWait)
-
             RateLimitResponse.fail(
                 allowed = false,
                 limit = limitRequestPerTime.limitCount,
                 0L,
-                retryAfter = retryAfterTime
+                retryAfter = retryTimeStorage[key]
             )
         }
     }
 
     private fun resolveBucket(key: String, limitRequestPerTime: LimitRequestPerTime): Bucket {
-        return tokenStorage.computeIfAbsent(key) {
+        val ttl = TimeUtil.toDuration(limitRequestPerTime.ttl, limitRequestPerTime.ttlTimeUnit)
+
+        retryTimeStorage.computeIfAbsent(key) {
+            LocalDateTime.now().plus(ttl)
+        }
+
+        return bucketStorage.computeIfAbsent(key) {
             Bucket.builder()
                 .addLimit { limit ->
                     limit.capacity(limitRequestPerTime.limitCount)
                         .refillIntervally( // 1분마다 토큰 채움
                             limitRequestPerTime.limitCount,
-                            toDuration(limitRequestPerTime.ttl, limitRequestPerTime.ttlTimeUnit)
+                            ttl
                         )
                 }
                 .build()
         }
-    }
-
-    private fun toDuration(amount: Long, unit: TimeUnit): Duration {
-        val millis = unit.toMillis(amount)
-        return Duration.ofMillis(millis)
     }
 
 }

--- a/movie-common/src/main/kotlin/com/example/common/ratelimit/Bucket4jRateLimiter.kt
+++ b/movie-common/src/main/kotlin/com/example/common/ratelimit/Bucket4jRateLimiter.kt
@@ -5,26 +5,41 @@ import com.example.common.model.RateLimitResponse
 import io.github.bucket4j.Bucket
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.time.LocalDateTime
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 @Component("Bucket4jRateLimiter")
 class Bucket4jRateLimiter: RateLimiter {
 
-    private val cache = ConcurrentHashMap<String, Bucket>()
+    private val tokenStorage = ConcurrentHashMap<String, Bucket>()
 
     override fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): RateLimitResponse {
         val bucket = resolveBucket(key, limitRequestPerTime)
 
-        return RateLimitResponse(
-            bucket.tryConsume(1),
-            limitRequestPerTime.limitCount,
-            bucket.availableTokens
-        )
+        val probe = bucket.tryConsumeAndReturnRemaining(1)
+
+        return if (probe.isConsumed) {
+            RateLimitResponse.success(
+                allowed = true,
+                limit = limitRequestPerTime.limitCount,
+                probe.remainingTokens
+            )
+        } else {
+            val nanosToWait = probe.nanosToWaitForRefill
+            val retryAfterTime = LocalDateTime.now().plusNanos(nanosToWait)
+
+            RateLimitResponse.fail(
+                allowed = false,
+                limit = limitRequestPerTime.limitCount,
+                0L,
+                retryAfter = retryAfterTime
+            )
+        }
     }
 
     private fun resolveBucket(key: String, limitRequestPerTime: LimitRequestPerTime): Bucket {
-        return cache.computeIfAbsent(key) {
+        return tokenStorage.computeIfAbsent(key) {
             Bucket.builder()
                 .addLimit { limit ->
                     limit.capacity(limitRequestPerTime.limitCount)

--- a/movie-common/src/main/kotlin/com/example/common/ratelimit/RateLimiter.kt
+++ b/movie-common/src/main/kotlin/com/example/common/ratelimit/RateLimiter.kt
@@ -1,9 +1,10 @@
 package com.example.common.ratelimit
 
 import com.example.common.annotation.LimitRequestPerTime
+import com.example.common.model.RateLimitResponse
 
 interface RateLimiter {
 
-    fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): Boolean
+    fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): RateLimitResponse
 
 }

--- a/movie-common/src/main/kotlin/com/example/common/ratelimit/RedisLuaRateLimiter.kt
+++ b/movie-common/src/main/kotlin/com/example/common/ratelimit/RedisLuaRateLimiter.kt
@@ -1,6 +1,7 @@
 package com.example.common.ratelimit
 
 import com.example.common.annotation.LimitRequestPerTime
+import com.example.common.model.RateLimitResponse
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.stereotype.Component
@@ -8,16 +9,22 @@ import java.util.concurrent.TimeUnit
 
 @Component("RedisLuaRateLimiter")
 class RedisLuaRateLimiter(
-    private val rateLimitScript: RedisScript<Boolean>,
+    private val rateLimitScript: RedisScript<List<*>>,
     private val redisTemplate: RedisTemplate<String, Any>
 ): RateLimiter {
 
-    override fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): Boolean {
-        return redisTemplate.execute(
+    override fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): RateLimitResponse {
+        val result = redisTemplate.execute(
             rateLimitScript,
             listOf(key),
             limitRequestPerTime.limitCount,
             TimeUnit.SECONDS.convert(limitRequestPerTime.ttl, limitRequestPerTime.ttlTimeUnit)
+        )
+
+        return RateLimitResponse(
+            allowed = (result[0] as Long) == 1L,
+            limit = (result[1] as Long),
+            remaining = (result[2] as Long)
         )
     }
 

--- a/movie-common/src/main/kotlin/com/example/common/ratelimit/RedisRateLimiter.kt
+++ b/movie-common/src/main/kotlin/com/example/common/ratelimit/RedisRateLimiter.kt
@@ -2,10 +2,11 @@ package com.example.common.ratelimit
 
 import com.example.common.annotation.LimitRequestPerTime
 import com.example.common.model.RateLimitResponse
+import com.example.common.util.TimeUtil
+import org.springframework.data.redis.core.HashOperations
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
-import java.util.concurrent.TimeUnit
 
 @Component("RedisRateLimiter")
 class RedisRateLimiter(
@@ -13,36 +14,49 @@ class RedisRateLimiter(
 ): RateLimiter {
 
     override fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): RateLimitResponse {
-        val previousCount = (redisTemplate.opsForValue().get(key) as? Number)?.toLong()
+        val ops = redisTemplate.opsForHash<String, String>()
 
-        if (previousCount != null && previousCount >= limitRequestPerTime.limitCount) {
-            val ttlSeconds = redisTemplate.getExpire(key, TimeUnit.SECONDS)
-
-            val retryAfter = if (ttlSeconds > 0) {
-                LocalDateTime.now().plusSeconds(ttlSeconds)
-            } else {
-                null
-            }
+        val remainingStr = ops.get(key, "remaining")
+        if (remainingStr == "0") {
+            val retryAfterStr = ops.get(key, "retryAfter")
 
             return RateLimitResponse.fail(
                 false,
                 limitRequestPerTime.limitCount,
                 0L,
-                retryAfter
+                retryAfterStr?.let { LocalDateTime.parse(it) } ?: LocalDateTime.now()
             )
         }
 
-        if (previousCount == null) {
-            redisTemplate.opsForValue().set(key, 0, limitRequestPerTime.ttl, limitRequestPerTime.ttlTimeUnit)
+        // 없으면 초기화
+        if (remainingStr == null) {
+            initializeRateLimitKeyIfAbsent(key, limitRequestPerTime, ops)
         }
 
-        val currentCount = redisTemplate.opsForValue().increment(key)!!
+        // 요청 제한 수 감소
+        val currentCount = ops.get(key, "remaining")?.toLong()?.minus(1L) ?: 0L
+        ops.put(key, "remaining", currentCount.toString())
 
         return RateLimitResponse.success(
             true,
             limitRequestPerTime.limitCount,
-            limitRequestPerTime.limitCount - currentCount
+            currentCount
         )
+    }
+
+    private fun initializeRateLimitKeyIfAbsent(
+        key: String,
+        limitRequestPerTime: LimitRequestPerTime,
+        ops: HashOperations<String, String, String>
+    ) {
+        val ttl = TimeUtil.toDuration(limitRequestPerTime.ttl, limitRequestPerTime.ttlTimeUnit)
+        val remaining = limitRequestPerTime.limitCount
+        val retryAfter = LocalDateTime.now().plus(ttl)
+
+        ops.put(key, "remaining", remaining.toString())
+        ops.put(key, "retryAfter", retryAfter.toString())
+
+        redisTemplate.expire(key, ttl)
     }
 
 }

--- a/movie-common/src/main/kotlin/com/example/common/util/TimeUtil.kt
+++ b/movie-common/src/main/kotlin/com/example/common/util/TimeUtil.kt
@@ -1,0 +1,20 @@
+package com.example.common.util
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+class TimeUtil {
+
+    companion object {
+        fun toDuration(amount: Long, unit: TimeUnit): Duration =
+            when (unit) {
+                TimeUnit.SECONDS -> Duration.ofSeconds(amount)
+                TimeUnit.MINUTES -> Duration.ofMinutes(amount)
+                TimeUnit.MILLISECONDS -> Duration.ofMillis(amount)
+                TimeUnit.HOURS -> Duration.ofHours(amount)
+                TimeUnit.DAYS -> Duration.ofDays(amount)
+                else -> throw IllegalArgumentException("Unsupported TimeUnit: $unit")
+            }
+    }
+
+}

--- a/movie-common/src/main/resources/luascript/ratelimit.lua
+++ b/movie-common/src/main/resources/luascript/ratelimit.lua
@@ -1,16 +1,16 @@
 local key = KEYS[1] -- 제한 키
 local limitCount = tonumber(ARGV[1]) -- 요청 허용 횟수
 local ttl = tonumber(ARGV[2]) -- ttl 값
-local current = redis.call('GET', key)
 
+local current = redis.call('GET', key)
 if current then
 	current = tonumber(current)
 	if current >= limitCount then
-	    return 0
+	    return {0, limitCount, 0}
     end
 else
     redis.call('SET', key, 0, 'EX', ttl)
 end
 
-redis.call('INCR', key)
-return 1
+local newCount = redis.call('INCR', key)
+return {1, limitCount, limitCount - newCount}


### PR DESCRIPTION
### 작업 이슈
- #1 

---

### 변경 사항
**AS-IS**
- 처리율 제한 정보(최대 요청 수, 남은 요청 수, 재시도 시간)를 서버 내에서만 관리
- 클라이언트는 **특정 API에 대한 처리율 제한 적용 유무를 알지 못하고, 요청 제한 시 예외 메시지만 응답** 받게 됨
- 성공 응답을 받기 위해 요청을 반복한다면 서버 부하 ↑

**TO-BE**
- 처리율 제한 정보를 HTTP Header 에 담아 응답
- 클라이언트는 **자기 요청에 대한 처리율 제한(throttle)을 감지**
- 응답 받은 처리율 제한 정보를 토대로 요청 수 조절 가능

---

### 처리율 제한 반환 타입 변경
기존에는 처리 여부만 확인할 수 있도록 Boolean 타입으로 반환하고 있었음.
처리 여부뿐만 아니라 다른 정보들까지 전달하기 위해 객체 타입으로 변경할 필요성 인지.
- Boolean -> RateLimitResponse
```kotlin
interface RateLimiter {

    fun tryCall(key: String, limitRequestPerTime: LimitRequestPerTime): RateLimitResponse

}
```
```kotlin
data class RateLimitResponse(
    val allowed: Boolean,                   // 처리 여부
    val limit: Long,                        // 최대 요청 수
    val remaining: Long,                    // 남은 요청 수
    val retryAfter: LocalDateTime? = null   // 재시도 시간
)
````
retryAfter 를 nullable 하게 한 이유는 요청이 성공했을 때 재시도 시간을 전달할 필요성을 느끼지 못했기 때문.
요청이 실패했을 때만 재시도 시간을 전달하여 불필요한 요청을 줄일 수 있도록 함.

요청 성공과 실패를 구분하기 위해 정적 메서드 추가
```kotlin
companion object {
    fun success(allowed: Boolean, limit: Long, remaining: Long): RateLimitResponse {
        return RateLimitResponse(allowed, limit, remaining, null)
    }

    fun fail(allowed: Boolean, limit: Long, remaining: Long, retryAfter: LocalDateTime?): RateLimitResponse {
        return RateLimitResponse(allowed, limit, remaining, retryAfter)
    }
}
```

### 타입 변경에 따른 구현체 수정

**AS-IS**
- 구현체는 @LimitRequestPerTime 이 적용된 API에 대해 key와 처리율 제한 정책 정보를 전달받음
- key 유무에 따라 요청 처리 여부 반환
    - key 없다면 생성 후, 요청 횟수 감소
    - key 있다면 메모리에서 조회 후, 요청 횟수 감소

**TO-BE**
key 를 생성하는 시점에 재시도 시간을 계산하고 메모리에 저장
- Bucket4J : Bucket(남은 요청 수) 저장소와 재시도 시간 저장소를 분리하고 같은 key로 조회할 수 있도록 수정
```kotlin
class Bucket4jRateLimiter: RateLimiter {
    private val bucketStorage = ConcurrentHashMap<String, Bucket>()
    private val retryTimeStorage = ConcurrentHashMap<String, LocalDateTime>()
}
```

- Redis : 하나의 key 안에 여러 속성을 담을 수 있는 Hash 자료구조 사용
```kotlin
class RedisRateLimiter(
    private val redisTemplate: RedisTemplate<String, Any>
): RateLimiter {
    override fun tryCall(...) : RateLimitResponse {
        val ops = redisTemplate.opsForHash<String, String>()

        // key 생성
        ops.put(key, "remaining", remaining.toString())
        ops.put(key, "retryAfter", retryAfter.toString()) 
    }
}
```

- Lua script : Redis 방식과 동일하며 반환되는 값들을 RateLimitResponse에 매핑
```lua
-- Lua script
redis.call("HSET", key, "remaining", -- args)
redis.call("HSET", key, "retryAfter", --args)
redis.call("EXPIRE", key, --args)
return {1, limit - 1, 0} -- 성공, 남은 요청, retryAfter 0 전달
```
```kotlin
// Kotlin
 RateLimitResponse(
    allowed = result[0] == "1",
    limit = 최대 요청 수,
    remaining = result[1].toLong(),
    retryAfter = if (result[2] == "0") {
        null
    } else {
        LocalDateTime.parse(result[2])
    }
)
```